### PR TITLE
ci: Update GitHub Actions runner to use CLOUDSHELL

### DIFF
--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -18,7 +18,7 @@ concurrency:
 jobs:
   build-and-push:
     timeout-minutes: 1440
-    runs-on: template_runner
+    runs-on: CLOUDSHELL
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
## Summary
- Updated the GitHub Actions workflow to use the `CLOUDSHELL` runner instead of `template_runner`
- This aligns with the GitHub runner that is installed and configured via the cloud-init configuration

## Changes
- Modified `.github/workflows/devcontainer.yml` to change `runs-on: template_runner` to `runs-on: CLOUDSHELL`

## Test plan
- [ ] Verify the workflow runs successfully with the new runner
- [ ] Confirm the CLOUDSHELL runner is registered and available in the organization
- [ ] Monitor the build process for any issues

🤖 Generated with [Claude Code](https://claude.ai/code)