### PR TITLE
fix: Update checkout action to v4 for runner compatibility

### DIFF
--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - name: Checkout
         id: checkout
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+        uses: actions/checkout@v4
 
       - name: Free Disk Space
         uses: jlumbroso/free-disk-space@main


### PR DESCRIPTION
## Summary
- Updates the checkout action from a specific SHA to v4 tag
- Resolves Node 24 compatibility issue with runner version 2.321.0
- Ensures GitHub Actions workflow can run on self-hosted runner

## Problem
The self-hosted runner (version 2.321.0) was failing with:
```
'using: node24' is not supported, use 'docker', 'node12', 'node16' or 'node20' instead.
```

## Solution
Updated to checkout@v4 which uses Node 20 and is compatible with the current runner version.

## Test Plan
- [x] Workflow runs successfully on self-hosted runner
- [x] Checkout action completes without errors