### PR TITLE
fix: add Node.js PATH for devcontainer command in GitHub Actions

### DIFF
--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -36,6 +36,7 @@ jobs:
 
       - name: Build container
         run: |
+          export PATH="/usr/local/nvm/versions/node/v24.6.0/bin:$PATH"
           devcontainer build \
             --workspace-folder src/devcontainer \
             --image-name ghcr.io/${{ github.repository_owner }}/devcontainer \


### PR DESCRIPTION
## Summary
• Fix "devcontainer: command not found" error in GitHub Actions workflow
• Add explicit PATH export to include NVM Node.js binaries location
• Ensures ubuntu user can access devcontainer CLI during workflow runs

## Root Cause
The devcontainer CLI is installed via NVM at `/usr/local/nvm/versions/node/v24.6.0/bin/devcontainer` but the GitHub Actions runner's ubuntu user doesn't have this path in the default environment.

## Solution
Export the full NVM Node.js path before running devcontainer commands in the workflow.

## Test plan
- [ ] Verify workflow runs without "command not found" errors
- [ ] Confirm devcontainer build completes successfully
- [ ] Validate container push to registry works

🤖 Generated with [Claude Code](https://claude.ai/code)