### PR TITLE
fix: configure ubuntu user profile for devcontainer CLI access

### DIFF
--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -36,7 +36,6 @@ jobs:
 
       - name: Build container
         run: |
-          export PATH="/usr/local/nvm/versions/node/v24.6.0/bin:$PATH"
           devcontainer build \
             --workspace-folder src/devcontainer \
             --image-name ghcr.io/${{ github.repository_owner }}/devcontainer \


### PR DESCRIPTION
## Summary
• Revert hardcoded PATH export from GitHub Actions workflow
• Add NVM Node.js binaries path to ubuntu user's `.bashrc`  
• Clean solution for devcontainer CLI availability in GitHub Actions

## Problem
The devcontainer CLI installed via NVM at `/usr/local/nvm/versions/node/v24.6.0/bin/` wasn't available to the ubuntu user running GitHub Actions because the path wasn't in the user's profile.

## Solution
Instead of patching individual workflows, configure the ubuntu user's shell profile to include the NVM Node.js binaries in PATH permanently.

## Test Results
```bash
sudo -u ubuntu bash -l -c "which devcontainer"
# /usr/local/nvm/versions/node/v24.6.0/bin/devcontainer

sudo -u ubuntu bash -l -c "devcontainer --version"  
# 0.80.0
```

## Test plan
- [ ] Verify GitHub Actions workflow runs without "command not found" errors
- [ ] Confirm devcontainer build and push completes successfully
- [ ] Validate this approach works for all future workflows

🤖 Generated with [Claude Code](https://claude.ai/code)