### PR TITLE
fix: add Node.js setup and devcontainer CLI installation to workflow

### DIFF
--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -27,6 +27,14 @@ jobs:
         id: checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          
+      - name: Install devcontainer CLI
+        run: npm install -g @devcontainers/cli
+
       - name: Log in to the Container registry
         uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1
         with:


### PR DESCRIPTION
## Summary
• Add `actions/setup-node@v4` to configure Node.js 24 environment properly
• Install `@devcontainers/cli` globally via npm during workflow execution
• Clean, maintainable solution without hardcoded paths
• Ensures devcontainer CLI availability across different runner environments

## Approach
Instead of relying on pre-installed Node.js/npm or system PATH configuration, this solution:
1. **Sets up Node.js**: Uses official GitHub Action to configure Node.js 24
2. **Installs CLI**: Installs devcontainer CLI as part of the workflow
3. **No hardcoded paths**: Relies on GitHub Actions' PATH management
4. **Maintainable**: Version-controlled and environment-independent

## Benefits
- ✅ Works on any GitHub Actions runner
- ✅ No hardcoded system paths  
- ✅ Version-controlled dependency management
- ✅ Clear, explicit workflow steps
- ✅ Handles Node.js version consistency

## Test plan
- [ ] Verify Node.js 24 is properly set up
- [ ] Confirm devcontainer CLI installation succeeds
- [ ] Validate devcontainer build and push complete successfully
- [ ] Ensure workflow is robust across different runner states

🤖 Generated with [Claude Code](https://claude.ai/code)