### PR TITLE
revert: remove Node.js setup from workflow, use CloudShell VM cloud-init

### DIFF
--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -27,14 +27,6 @@ jobs:
         id: checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '24'
-          
-      - name: Install devcontainer CLI
-        run: npm install -g @devcontainers/cli
-
       - name: Log in to the Container registry
         uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1
         with:


### PR DESCRIPTION
Reverts workflow to clean state. The CloudShell VM already has devcontainer CLI installed via cloud-init configuration.